### PR TITLE
Add and configure rubocop-packaging gem

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,6 @@
-inherit_gem:
-  rubocop-cargosense: config/default.yml
+inherit_from: config/default.yml
+
+require: rubocop-packaging
 
 AllCops:
   TargetRubyVersion: "3.0"

--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,4 @@ source "https://rubygems.org"
 gemspec
 
 gem "rake"
+gem "rubocop-packaging"


### PR DESCRIPTION
> [rubocop-packaging] helps to enforce some of the guidelines that are
> expected of upstream maintainers so that the downstream can build
> their packages in a clean environment without any problems.

See: https://docs.rubocop.org/rubocop-packaging