### PR TITLE
Set `await-release` in rubygems/release-gem step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,6 +22,8 @@ jobs:
           bundler-cache: true
           ruby-version: "3.0"
       - uses: rubygems/release-gem@v1
+        with:
+          await-release: false
   publish-to-github-packages:
     name: Publish to GitHub Packages
     permissions:


### PR DESCRIPTION
Tripped face first into this one again:

https://github.com/rubygems/release-gem/issues/1

I was hopeful that Ruby 3.0 would ship with a new enough verson of RubyGems to support `gem exec` _but alas_.

Ruby 3.2.2 was the first to ship with a version > v3.4.8.

See: https://stdgems.org/rubygems/