### PR TITLE
Test minimum dependency versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,14 @@ on:
 
 jobs:
   test:
-    name: Ruby ${{ matrix.ruby }}
+    name: Ruby ${{ matrix.ruby }} » ${{matrix.gemfile}}
     runs-on: ubuntu-latest
+    env:
+      BUNDLE_GEMFILE: ${{ matrix.gemfile }}
     strategy:
       fail-fast: false
       matrix:
+        gemfile: [Gemfile, gemfiles/minimum_dependencies.gemfile]
         ruby: ["3.0", "3.1", "3.2", "3.3"]
     steps:
       - uses: actions/checkout@v4

--- a/gemfiles/minimum_dependencies.gemfile
+++ b/gemfiles/minimum_dependencies.gemfile
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+eval_gemfile "../Gemfile"
+
+File
+  .read("rubocop-cargosense.gemspec")
+  .each_line(chomp: true)
+  .grep(/add_runtime_dependency/) { |line| line.scan(/add_runtime_dependency "(.+)", "~> (.+)"$/).flatten }
+  .each { |line| gem line[0], line[1] }


### PR DESCRIPTION
Derived from Shopify's [`gemfiles/minimum_rubocop.gemfile`](https://github.com/Shopify/ruby-style-guide/blob/main/gemfiles/minimum_rubocop.gemfile).

The newly-added `gemfiles/minimum_dependencies.gemfile` is used in a CI workflow to test that the gem's minimum specified dependencies pass. "Normal" builds will install up-to-date version of dependencies. The Ruby code in this file reads from the `rubocop-cargosense.gemspec` file and parses any `add_runtime_dependency` declarations for the gem and the version. Those pairs are used to generate `gem "foo", "0.0.0"`-style commands.

The updated CI workflow tests that the gem's minimum
specified dependencies pass. "Normal" builds will install up-to-date
version of dependencies.