### PR TITLE
Add and configure rubocop-rails

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,3 +8,6 @@ AllCops:
 Naming/FileName:
   Exclude:
     - lib/rubocop-cargosense.rb
+
+Rails:
+  Enabled: false

--- a/config/default.yml
+++ b/config/default.yml
@@ -1,6 +1,7 @@
 inherit_from:
   - ./rubocop.yml
   - ./rubocop-performance.yml
+  - ./rubocop-rails.yml
   - ./rubocop-rake.yml
 
 inherit_mode:

--- a/config/rubocop-rails.yml
+++ b/config/rubocop-rails.yml
@@ -1,0 +1,34 @@
+# Automatic Rails code style checking tool. A RuboCop extension focused on
+# enforcing Rails best practices and coding conventions.
+#
+# @see https://rubygems.org/gems/rubocop-rails
+# @see https://docs.rubocop.org/rubocop-rails
+# @see https://github.com/rubocop/rubocop-rails
+
+require: rubocop-rails
+
+Rails/DefaultScope:
+  Enabled: true
+
+Rails/EnvironmentVariableAccess:
+  Enabled: true
+  AllowReads: true
+
+Rails/OrderById:
+  Enabled: true
+
+Rails/PluckId:
+  Enabled: true
+
+Rails/RequireDependency:
+  Enabled: true
+
+Rails/ReversibleMigrationMethodDefinition:
+  Enabled: true
+
+Rails/SaveBang:
+  Enabled: true
+  AllowImplicitReturn: false
+
+Rails/TableNameAssignment:
+  Enabled: true

--- a/rubocop-cargosense.gemspec
+++ b/rubocop-cargosense.gemspec
@@ -26,5 +26,6 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "rubocop", "~> 1.59"
   spec.add_runtime_dependency "rubocop-performance", "~> 1.20"
+  spec.add_runtime_dependency "rubocop-rails", "~> 2.23"
   spec.add_runtime_dependency "rubocop-rake", "~> 0.6"
 end


### PR DESCRIPTION
Adds the [rubocop-rails](https://github.com/rubocop/rubocop-rails) gem and enables and/or configures some of its rules.