### PR TITLE
Add RSpec, Capybara, and FactoryBot gems/configs

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -1,8 +1,11 @@
 inherit_from:
   - ./rubocop.yml
+  - ./rubocop-capybara.yml
+  - ./rubocop-factory_bot.yml
   - ./rubocop-performance.yml
   - ./rubocop-rails.yml
   - ./rubocop-rake.yml
+  - ./rubocop-rspec.yml
 
 inherit_mode:
   merge:

--- a/config/rubocop-capybara.yml
+++ b/config/rubocop-capybara.yml
@@ -1,0 +1,8 @@
+# Code style checking for Capybara test files (RSpec, Cucumber, Minitest). A
+# plugin for the RuboCop code style enforcing & linting tool.
+#
+# @see https://rubygems.org/gems/rubocop-capybara
+# @see https://docs.rubocop.org/rubocop-capybara
+# @see https://github.com/rubocop/rubocop-capybara
+
+require: rubocop-capybara

--- a/config/rubocop-factory_bot.yml
+++ b/config/rubocop-factory_bot.yml
@@ -1,0 +1,8 @@
+# Code style checking for factory_bot files. A plugin for the RuboCop code style
+# enforcing & linting tool.
+#
+# @see https://rubygems.org/gems/rubocop-factory_bot
+# @see https://docs.rubocop.org/rubocop-factory_bot
+# @see https://github.com/rubocop/rubocop-factory_bot
+
+require: rubocop-factory_bot

--- a/config/rubocop-rspec.yml
+++ b/config/rubocop-rspec.yml
@@ -1,0 +1,21 @@
+# Code style checking for RSpec files. A plugin for the RuboCop code style
+# enforcing & linting tool.
+#
+# @see https://rubygems.org/gems/rubocop-rspec
+# @see https://docs.rubocop.org/rubocop-rspec
+# @see https://github.com/rubocop/rubocop-rspec
+
+require: rubocop-rspec
+
+RSpec/DescribedClassModuleWrapping:
+  Enabled: true
+
+RSpec/ExampleLength:
+  CountAsOne:
+    - array
+    - hash
+    - heredoc
+    - method_call
+
+RSpec/MessageExpectation:
+  Enabled: true

--- a/rubocop-cargosense.gemspec
+++ b/rubocop-cargosense.gemspec
@@ -25,7 +25,10 @@ Gem::Specification.new do |spec|
   }
 
   spec.add_runtime_dependency "rubocop", "~> 1.59"
+  spec.add_runtime_dependency "rubocop-capybara", "~> 2.20"
+  spec.add_runtime_dependency "rubocop-factory_bot", "~> 2.25"
   spec.add_runtime_dependency "rubocop-performance", "~> 1.20"
   spec.add_runtime_dependency "rubocop-rails", "~> 2.23"
   spec.add_runtime_dependency "rubocop-rake", "~> 0.6"
+  spec.add_runtime_dependency "rubocop-rspec", "~> 2.26"
 end


### PR DESCRIPTION
Adds the following gem dependencies:

- [rubocop-capybara](https://rubygems.org/gems/rubocop-capybara)
- [rubocop-factory_bot](https://rubygems.org/gems/rubocop-factory_bot)
- [rubocop-rspec](https://rubygems.org/gems/rubocop-rspec)
