### PR TITLE
Fix CI jobs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,12 @@
 version: 2
 
 updates:
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "CargoSense/ruby-reviewers"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,4 +26,6 @@ jobs:
         with:
           bundler-cache: true
           ruby-version: ${{ matrix.ruby }}
+      - name: RuboCop version
+        run: bundle info rubocop | head -1
       - run: bundle exec rake

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 /.ruby-lsp/
 /coverage/
 /pkg/
-Gemfile.lock

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,6 +87,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-linux
 
 DEPENDENCIES
   rake

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,97 @@
+PATH
+  remote: .
+  specs:
+    rubocop-cargosense (0.2.0)
+      rubocop (~> 1.59)
+      rubocop-capybara (~> 2.20)
+      rubocop-factory_bot (~> 2.25)
+      rubocop-performance (~> 1.20)
+      rubocop-rails (~> 2.23)
+      rubocop-rake (~> 0.6)
+      rubocop-rspec (~> 2.26)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (7.1.3)
+      base64
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      mutex_m
+      tzinfo (~> 2.0)
+    ast (2.4.2)
+    base64 (0.2.0)
+    bigdecimal (3.1.6)
+    concurrent-ruby (1.2.3)
+    connection_pool (2.4.1)
+    drb (2.2.0)
+      ruby2_keywords
+    i18n (1.14.1)
+      concurrent-ruby (~> 1.0)
+    json (2.7.1)
+    language_server-protocol (3.17.0.3)
+    minitest (5.22.2)
+    mutex_m (0.2.0)
+    parallel (1.24.0)
+    parser (3.3.0.5)
+      ast (~> 2.4.1)
+      racc
+    racc (1.7.3)
+    rack (3.0.9)
+    rainbow (3.1.1)
+    rake (13.1.0)
+    regexp_parser (2.9.0)
+    rexml (3.2.6)
+    rubocop (1.60.2)
+      json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
+      parallel (~> 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.30.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.30.0)
+      parser (>= 3.2.1.0)
+    rubocop-capybara (2.20.0)
+      rubocop (~> 1.41)
+    rubocop-factory_bot (2.25.1)
+      rubocop (~> 1.41)
+    rubocop-packaging (0.5.2)
+      rubocop (>= 1.33, < 2.0)
+    rubocop-performance (1.20.2)
+      rubocop (>= 1.48.1, < 2.0)
+      rubocop-ast (>= 1.30.0, < 2.0)
+    rubocop-rails (2.23.1)
+      activesupport (>= 4.2.0)
+      rack (>= 1.1)
+      rubocop (>= 1.33.0, < 2.0)
+      rubocop-ast (>= 1.30.0, < 2.0)
+    rubocop-rake (0.6.0)
+      rubocop (~> 1.0)
+    rubocop-rspec (2.26.1)
+      rubocop (~> 1.40)
+      rubocop-capybara (~> 2.17)
+      rubocop-factory_bot (~> 2.22)
+    ruby-progressbar (1.13.0)
+    ruby2_keywords (0.0.5)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    unicode-display_width (2.5.0)
+
+PLATFORMS
+  aarch64-linux
+
+DEPENDENCIES
+  rake
+  rubocop-cargosense!
+  rubocop-packaging
+
+BUNDLED WITH
+   2.4.19

--- a/rubocop-cargosense.gemspec
+++ b/rubocop-cargosense.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.metadata = {
     "bug_tracker_uri" => "#{spec.homepage}/issues",
-    "changelog_uri" => "#{spec.homepage}//releases",
+    "changelog_uri" => "#{spec.homepage}/releases",
     "rubygems_mfa_required" => "true",
     "source_code_uri" => "#{spec.homepage}/tree/v#{spec.version}"
   }


### PR DESCRIPTION
I noticed that scheduled CI jobs weren't picking up up-to-date RuboCop versions. The minimum gemfile jobs are working, but I'd expect the standard run would grab the latest and greatest. Not so since, absent a `Gemfile.lock`, the CI job is going to fall back to the cache. That has the older gem versions.

Looking back at [Shopify/ruby-style-guide](https://github.com/Shopify/ruby-style-guide) (which served as a reference point for this testing strategy in the first place), I found that they check in `Gemfile.lock`, have Dependabot do regular updates, and their setup with current dependency versions and minimum versions seems to be working just fine.

So, we're gonna give that a shot.