### PR TITLE
Add rubocop-rspec_rails

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,8 @@ PATH
       rubocop-performance (~> 1.20)
       rubocop-rails (~> 2.23)
       rubocop-rake (~> 0.6)
-      rubocop-rspec (~> 2.26)
+      rubocop-rspec (~> 2.28)
+      rubocop-rspec_rails (~> 2.28)
 
 GEM
   remote: https://rubygems.org/
@@ -74,10 +75,13 @@ GEM
       rubocop-ast (>= 1.31.1, < 2.0)
     rubocop-rake (0.6.0)
       rubocop (~> 1.0)
-    rubocop-rspec (2.27.1)
+    rubocop-rspec (2.29.1)
       rubocop (~> 1.40)
       rubocop-capybara (~> 2.17)
       rubocop-factory_bot (~> 2.22)
+      rubocop-rspec_rails (~> 2.28)
+    rubocop-rspec_rails (2.28.3)
+      rubocop (~> 1.40)
     ruby-progressbar (1.13.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rubocop-cargosense (0.2.0)
+    rubocop-cargosense (1.0.0)
       rubocop (~> 1.59)
       rubocop-capybara (~> 2.20)
       rubocop-factory_bot (~> 2.25)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ PATH
       rubocop-rails (~> 2.23)
       rubocop-rake (~> 0.6)
       rubocop-rspec (~> 2.28)
-      rubocop-rspec_rails (~> 2.28)
+      rubocop-rspec_rails (~> 2.28.1)
 
 GEM
   remote: https://rubygems.org/

--- a/config/default.yml
+++ b/config/default.yml
@@ -6,6 +6,7 @@ inherit_from:
   - ./rubocop-rails.yml
   - ./rubocop-rake.yml
   - ./rubocop-rspec.yml
+  - ./rubocop-rspec_rails.yml
 
 inherit_mode:
   merge:

--- a/config/rubocop-rspec_rails.yml
+++ b/config/rubocop-rspec_rails.yml
@@ -1,0 +1,8 @@
+# Code style checking for RSpec Rails files. A plugin for the RuboCop code style
+# enforcing & linting tool.
+#
+# @see https://rubygems.org/gems/rubocop-rspec_rails
+# @see https://docs.rubocop.org/rubocop-rspec_rails
+# @see https://github.com/rubocop/rubocop-rspec_rails
+
+require: rubocop-rspec_rails

--- a/rubocop-cargosense.gemspec
+++ b/rubocop-cargosense.gemspec
@@ -32,5 +32,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "rubocop-rails", "~> 2.23"
   spec.add_runtime_dependency "rubocop-rake", "~> 0.6"
   spec.add_runtime_dependency "rubocop-rspec", "~> 2.28"
-  spec.add_runtime_dependency "rubocop-rspec_rails", "~> 2.28"
+  spec.add_runtime_dependency "rubocop-rspec_rails", "~> 2.28.1"
 end

--- a/rubocop-cargosense.gemspec
+++ b/rubocop-cargosense.gemspec
@@ -31,5 +31,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "rubocop-performance", "~> 1.20"
   spec.add_runtime_dependency "rubocop-rails", "~> 2.23"
   spec.add_runtime_dependency "rubocop-rake", "~> 0.6"
-  spec.add_runtime_dependency "rubocop-rspec", "~> 2.26"
+  spec.add_runtime_dependency "rubocop-rspec", "~> 2.28"
+  spec.add_runtime_dependency "rubocop-rspec_rails", "~> 2.28"
 end

--- a/rubocop-cargosense.gemspec
+++ b/rubocop-cargosense.gemspec
@@ -4,7 +4,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 3.0"
 
   spec.name          = "rubocop-cargosense"
-  spec.version       = "0.2.0"
+  spec.version       = "1.0.0"
   spec.authors       = ["CargoSense"]
   spec.email         = ["rubygems@cargosense.com"]
 


### PR DESCRIPTION
From v2.28, [rubocop-rspec](https://github.com/rubocop/rubocop-rspec) split out Rails-specific rules into a new gem, [rubocop-rspec_rails](https://github.com/rubocop/rubocop-rspec_rails) whose initial version number matches rubocop-rspec.

This PR adds the new gem to this project's gemspec, adds a small config for rubocop-rspec_rails, and bumps this gem's version to v1.0.0. The update set a new minimum version for rubocop-rspec to account for the splitting off of the rubocop-rspec_rails gem. I think that raises to the level of a breaking change, so we go major version here.