### PR TITLE
Capybara/ClickLinkOrButtonStyle: Enforce strict style

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rubocop-cargosense (1.0.0)
+    rubocop-cargosense (1.1.0)
       rubocop (~> 1.59)
       rubocop-capybara (~> 2.20)
       rubocop-factory_bot (~> 2.25)

--- a/config/rubocop-capybara.yml
+++ b/config/rubocop-capybara.yml
@@ -6,3 +6,6 @@
 # @see https://github.com/rubocop/rubocop-capybara
 
 require: rubocop-capybara
+
+Capybara/ClickLinkOrButtonStyle:
+  EnforcedStyle: strict

--- a/rubocop-cargosense.gemspec
+++ b/rubocop-cargosense.gemspec
@@ -4,7 +4,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 3.0"
 
   spec.name          = "rubocop-cargosense"
-  spec.version       = "1.0.0"
+  spec.version       = "1.1.0"
   spec.authors       = ["CargoSense"]
   spec.email         = ["rubygems@cargosense.com"]
 


### PR DESCRIPTION
## Description

This rule's default enforce style, `link_or_button` [1], introduced a number of problems [2]. Specifically, I noticed issues switching to `click_on` from `click_button` [3]. The hack solution is to ignore or disable the rule in some places but not in others. Not great.

As a result, the rule is slated for removal [4] and replacement [5] by a new rule. In the interim, configuring this rule to enforce a strict use of `click_button` and `click_link` is preferential (and, honestly, more communicative).

In this author's opinion, user interface specs should be explicit about the markup under test.

[1] https://docs.rubocop.org/rubocop-capybara/cops_capybara.html#capybaraclicklinkorbuttonstyle
[2] rubocop/rubocop-capybara#61
[3] rubocop/rubocop-capybara#61 (comment)
[4] rubocop/rubocop-capybara#81
[5] rubocop/rubocop-capybara#99

## Commits

- Configure `Capybara/ClickLinkOrButtonStyle`
- Bump version to v1.1.0
