### PR TITLE
RuboCop: Gemspec/AddRuntimeDependency

### DIFF
--- a/rubocop-cargosense.gemspec
+++ b/rubocop-cargosense.gemspec
@@ -25,12 +25,12 @@ Gem::Specification.new do |spec|
     "source_code_uri" => "#{spec.homepage}/tree/v#{spec.version}"
   }
 
-  spec.add_runtime_dependency "rubocop", "~> 1.61"
-  spec.add_runtime_dependency "rubocop-capybara", "~> 2.20"
-  spec.add_runtime_dependency "rubocop-factory_bot", "~> 2.26.1"
-  spec.add_runtime_dependency "rubocop-performance", "~> 1.20"
-  spec.add_runtime_dependency "rubocop-rails", "~> 2.23"
-  spec.add_runtime_dependency "rubocop-rake", "~> 0.6"
-  spec.add_runtime_dependency "rubocop-rspec", "~> 3.0.1"
-  spec.add_runtime_dependency "rubocop-rspec_rails", "~> 2.30"
+  spec.add_dependency "rubocop", "~> 1.61"
+  spec.add_dependency "rubocop-capybara", "~> 2.20"
+  spec.add_dependency "rubocop-factory_bot", "~> 2.26.1"
+  spec.add_dependency "rubocop-performance", "~> 1.20"
+  spec.add_dependency "rubocop-rails", "~> 2.23"
+  spec.add_dependency "rubocop-rake", "~> 0.6"
+  spec.add_dependency "rubocop-rspec", "~> 3.0.1"
+  spec.add_dependency "rubocop-rspec_rails", "~> 2.30"
 end


### PR DESCRIPTION
> Use `add_dependency` instead of `add_runtime_dependency`.

Resolves errors first surfaced in #52.

References:

- https://rubystyle.guide#add_dependency_vs_add_runtime_dependency
- https://github.com/rubygems/rubygems/issues/7799#issuecomment-2192720316
