### PR TITLE
Use `add_dependency` in minimum gems script

### DIFF
--- a/gemfiles/minimum_dependencies.gemfile
+++ b/gemfiles/minimum_dependencies.gemfile
@@ -5,5 +5,5 @@ eval_gemfile "../Gemfile"
 File
   .read("rubocop-cargosense.gemspec")
   .each_line(chomp: true)
-  .grep(/add_runtime_dependency/) { |line| line.scan(/add_runtime_dependency "(.+)", "~> (.+)"$/).flatten }
+  .grep(/add_dependency/) { |line| line.scan(/add_runtime_dependency "(.+)", "~> (.+)"$/).flatten }
   .each { |line| gem line[0], line[1] }

--- a/gemfiles/minimum_dependencies.gemfile
+++ b/gemfiles/minimum_dependencies.gemfile
@@ -5,5 +5,5 @@ eval_gemfile "../Gemfile"
 File
   .read("rubocop-cargosense.gemspec")
   .each_line(chomp: true)
-  .grep(/add_dependency/) { |line| line.scan(/add_runtime_dependency "(.+)", "~> (.+)"$/).flatten }
+  .grep(/add_dependency/) { |line| line.scan(/add_dependency "(.+)", "~> (.+)"$/).flatten }
   .each { |line| gem line[0], line[1] }


### PR DESCRIPTION
Follows 06095f7.

> Use `add_dependency` instead of `add_runtime_dependency`.

References:

- https://rubystyle.guide#add_dependency_vs_add_runtime_dependency
- rubygems/rubygems#7799 (comment)