### PR TITLE
Update minimum supported Ruby to v3.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         gemfile: [Gemfile, gemfiles/minimum_dependencies.gemfile]
-        ruby: ["3.0", "3.1", "3.2", "3.3"]
+        ruby: [3.1, 3.2, 3.3]
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ inherit_from: config/default.yml
 require: rubocop-packaging
 
 AllCops:
-  TargetRubyVersion: "3.0"
+  TargetRubyVersion: 3.1
 
 Naming/FileName:
   Exclude:

--- a/rubocop-cargosense.gemspec
+++ b/rubocop-cargosense.gemspec
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Gem::Specification.new do |spec|
-  spec.required_ruby_version = ">= 3.0"
+  spec.required_ruby_version = ">= 3.1"
 
   spec.name          = "rubocop-cargosense"
   spec.version       = "2.0.0"


### PR DESCRIPTION
## Description

- Set `required_ruby_version` to `>= 3.1`. Ruby 3.0 is EOL'ed from 23 April 2024: https://endoflife.date/ruby
- Update RuboCop target Ruby version to 3.1
- Remove Ruby 3.0 from test matrix
  