### PR TITLE
Change `Style/HashSyntax` configuration

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     rubocop-cargosense (2.0.0)
-      rubocop (~> 1.61)
+      rubocop (~> 1.64)
       rubocop-capybara (~> 2.20)
       rubocop-factory_bot (~> 2.26.1)
       rubocop-performance (~> 1.20)

--- a/config/rubocop-style.yml
+++ b/config/rubocop-style.yml
@@ -25,7 +25,7 @@ Style/EmptyMethod:
   EnforcedStyle: expanded
 
 Style/HashSyntax:
-  EnforcedShorthandSyntax: never
+  EnforcedShorthandSyntax: either_consistent
 
 Style/MethodCalledOnDoEndBlock:
   Enabled: true

--- a/rubocop-cargosense.gemspec
+++ b/rubocop-cargosense.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
     "source_code_uri" => "#{spec.homepage}/tree/v#{spec.version}"
   }
 
-  spec.add_dependency "rubocop", "~> 1.61"
+  spec.add_dependency "rubocop", "~> 1.64"
   spec.add_dependency "rubocop-capybara", "~> 2.20"
   spec.add_dependency "rubocop-factory_bot", "~> 2.26.1"
   spec.add_dependency "rubocop-performance", "~> 1.20"


### PR DESCRIPTION
This change allows for the use of either pre-Ruby 3.1 hash syntax or the newer shorthand value omission style, so long as the use is consistent.

As such, the change to this configuration is likely non-breaking and shouldn't introduce a pile of errors in existing code.

> ```ruby
> # bad - `bar` value can be omitted
> {foo:, bar: bar}
>
> # bad - mixed syntaxes
> {foo:, bar: baz}
>
> # good - `foo` and `bar` values can be omitted, but they are
> # consistent, so it's accepted
> {foo: foo, bar: bar}
>
> # good
> {foo:, bar:}
>
> # good - can't omit `baz`
> {foo: foo, bar: baz}
> ```
